### PR TITLE
Migrate app from UIKit/Storyboards to SwiftUI

### DIFF
--- a/home-monitoring/BeaconManager.swift
+++ b/home-monitoring/BeaconManager.swift
@@ -73,13 +73,14 @@ extension BeaconManager: ESTDeviceConnectableDelegate {
 
     func estDeviceConnectionDidSucceed(_ device: ESTDeviceConnectable) {
         print("Connection Output Status: Connected")
+        let rawPressure = monitoringDevice?.settings?.sensors.pressure.getValue()
+        let rawTemperature = monitoringDevice?.settings?.sensors.temperature.getValue()
         Task { @MainActor in
             connectionState = .connected
-
-            if let rawPressure = monitoringDevice?.settings?.sensors.pressure.getValue() {
+            if let rawPressure {
                 pressure = Int(rawPressure / 100)
             }
-            if let rawTemperature = monitoringDevice?.settings?.sensors.temperature.getValue() {
+            if let rawTemperature {
                 temperature = Int(rawTemperature)
             }
         }

--- a/home-monitoring/BeaconManager.swift
+++ b/home-monitoring/BeaconManager.swift
@@ -73,23 +73,29 @@ extension BeaconManager: ESTDeviceConnectableDelegate {
 
     func estDeviceConnectionDidSucceed(_ device: ESTDeviceConnectable) {
         print("Connection Output Status: Connected")
-        connectionState = .connected
+        Task { @MainActor in
+            connectionState = .connected
 
-        if let rawPressure = monitoringDevice?.settings?.sensors.pressure.getValue() {
-            pressure = Int(rawPressure / 100)
-        }
-        if let rawTemperature = monitoringDevice?.settings?.sensors.temperature.getValue() {
-            temperature = Int(rawTemperature)
+            if let rawPressure = monitoringDevice?.settings?.sensors.pressure.getValue() {
+                pressure = Int(rawPressure / 100)
+            }
+            if let rawTemperature = monitoringDevice?.settings?.sensors.temperature.getValue() {
+                temperature = Int(rawTemperature)
+            }
         }
     }
 
     func estDevice(_ device: ESTDeviceConnectable, didFailConnectionWithError error: Error) {
         print("Connection Output Status: \(error.localizedDescription)")
-        connectionState = .error(error.localizedDescription)
+        Task { @MainActor in
+            connectionState = .error(error.localizedDescription)
+        }
     }
 
     func estDevice(_ device: ESTDeviceConnectable, didDisconnectWithError error: Error?) {
         print("Connection Output Status: Disconnected")
-        connectionState = .disconnected
+        Task { @MainActor in
+            connectionState = .disconnected
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project documentation and build instructions
- Migrate entire UI layer from UIKit/Storyboards to SwiftUI (iOS 17+, Swift 6), replacing `ViewController` and storyboards with `HomeMonitoringApp`, `ContentView`, and `BeaconManager` (ObservableObject)
- Ensure thread safety by dispatching all `@Published` property updates to the main thread in Estimote SDK delegate callbacks

## Test plan
- [ ] Build project in Xcode 15+ targeting a physical iPhone (iOS 17+)
- [ ] Verify temperature and pressure readings display correctly in the SwiftUI view
- [ ] Confirm beacon discovery, connection, and disconnection states update the UI without threading warnings
- [ ] Verify no storyboard references remain in the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)